### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/json/_json_print.pony
+++ b/json/_json_print.pony
@@ -29,7 +29,7 @@ primitive _JsonPrint
     """
     var buf = consume buf'
 
-    match d
+    match \exhaustive\ d
     | let x: Bool => buf.append(x.string())
     | let x: None => buf.append("null")
     | let x: String =>

--- a/json/json_doc.pony
+++ b/json/json_doc.pony
@@ -72,7 +72,7 @@ class JsonDoc
     Raise error on invalid or missing value.
     """
     _dump_whitespace()
-    match _peek_char(context)?
+    match \exhaustive\ _peek_char(context)?
     | let c: U8 if (c >= 'a') and (c <= 'z') => _parse_keyword()?
     | let c: U8 if (c >= '0') and (c <= '9') => _parse_number()?
     | '-' => _parse_number()?
@@ -350,7 +350,7 @@ class JsonDoc
 
     while i < 4 do
       let d =
-        match _get_char("Unicode escape sequence")?
+        match \exhaustive\ _get_char("Unicode escape sequence")?
         | let c: U8 if (c >= '0') and (c <= '9') => c - '0'
         | let c: U8 if (c >= 'a') and (c <= 'f') => (c - 'a') + 10
         | let c: U8 if (c >= 'A') and (c <= 'F') => (c - 'A') + 10
@@ -401,7 +401,7 @@ class JsonDoc
       // EOF found, is that OK?
       _last_index = -1
 
-      match eof_context
+      match \exhaustive\ eof_context
       | None => return 0  // EOF is allowed
       | let context: String =>
         // EOF not allowed


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.